### PR TITLE
Copilot/check tailscale build process

### DIFF
--- a/.github/workflows/build-tailscale.yaml
+++ b/.github/workflows/build-tailscale.yaml
@@ -71,7 +71,8 @@ jobs:
           eval `CGO_ENABLED=0 go run ./cmd/mkversion`
           
           # Generate extra-small tags and add ts_include_cli for combined binary support
-          EXTRA_SMALL_TAGS=$(go run ./cmd/featuretags --min --add=osrouter)
+          # Include unixsocketidentity to enable proper LocalAPI access control on Unix systems
+          EXTRA_SMALL_TAGS=$(go run ./cmd/featuretags --min --add=osrouter,unixsocketidentity)
           BUILD_TAGS="${EXTRA_SMALL_TAGS},ts_include_cli"
           
           # Set ldflags with version info and stripping (like --extra-small)
@@ -182,6 +183,7 @@ jobs:
 
             * Building a combined binary of `tailscale` and `tailscaled` with the `ts_include_cli` build tag
             * Using minimal feature tags for size optimization (equivalent to `--extra-small`)
+            * Including `unixsocketidentity` feature for proper LocalAPI access control on Unix/OpenWrt systems
             * Compressing the binary with UPX
 
             To use both programs, rename `tailscaled-OS-ARCH` to `tailscaled` and create a symbolic link (`ln -sv tailscaled tailscale`). When invoked as `tailscale`, it acts as the CLI; when invoked as `tailscaled`, it acts as the daemon.

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,16 @@ For standard (non-tiny) binaries, UPX compression:
 - 🔹 Requires `xz` (auto-installed if missing)
 - 🔹 Can be disabled with `--no-upx`
 
+### 🔧 Technical: Unix Socket Identity (v1.90+)
+
+Starting with Tailscale 1.90, the tiny binaries include the `unixsocketidentity` feature:
+- 🔹 Enables proper LocalAPI access control on Unix/OpenWrt systems
+- 🔹 Allows the daemon to identify users connecting via Unix sockets
+- 🔹 Prevents "Access denied: status access denied" errors
+- 🔹 Essential for commands like `tailscale status` to work correctly
+
+This feature was added to fix compatibility issues with Tailscale 1.90+ on OpenWrt.
+
 ---
 
 ## 💬 Feedback


### PR DESCRIPTION
Fix for issue that tailscale >1.88.3 isn't working with GL GUI