### PR TITLE
Determine correct mips architecture from OpenWrt release info

### DIFF
--- a/update-tailscale.sh
+++ b/update-tailscale.sh
@@ -177,11 +177,10 @@ preflight_check() {
         TINY_ARCH="amd64"
         log "SUCCESS" "Architecture: x86_64"
     elif [ "$ARCH" = "mips" ]; then
-    # Check for specific models that use mipsle architecture
-    if [ "$IS_GLINET" -eq 1 ]; then
-        MODEL=$(grep 'machine' /proc/cpuinfo | awk -F ': ' '{print $2}')
-        case "$MODEL" in
-            "GL.iNet GL-MT1300" | "GL-MT300N-V2" | "GL-SFT1200")
+        # Determine from OpenWrt release info if devices uses mipsle architecture
+        MIPS_ARCH=$(sed -n "s/^DISTRIB_ARCH='\(.*\)_.*'$/\1/p" /etc/openwrt_release)
+        case "$MIPS_ARCH" in
+            "mipsel")
                 TINY_ARCH="mipsle"
                 log "SUCCESS" "Architecture: mipsle"
                 ;;
@@ -191,10 +190,6 @@ preflight_check() {
                 ;;
         esac
     else
-        TINY_ARCH="mips"
-        log "SUCCESS" "Architecture: mips"
-    fi
-    else    
         log "ERROR" "This script only works on arm64, armv7, x86_64, mips and mipsle"
         PREFLIGHT=1
     fi


### PR DESCRIPTION
With this change, the script reads the `DISTRIB_ARCH` value from the `/etc/openwrt_release` file to determine whether the device uses mips or mipsle architecture. The GL.iNet-specific check is no longer necessary here as the OEM firmwares also include the `/etc/openwrt_release` file. This way, GL.iNet devices not using the OEM firmware as well as devices using mipsle from other manufacturers should also be correctly identified. Fixes #25.