### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-script.yaml
+++ b/.github/workflows/test-script.yaml
@@ -235,6 +235,8 @@ jobs:
   integration-check:
     name: Integration Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Admonstrator/glinet-tailscale-updater/security/code-scanning/7](https://github.com/Admonstrator/glinet-tailscale-updater/security/code-scanning/7)

To follow best practices, explicitly set the minimal permissions required for the workflow or job. As the `integration-check` job does not push, create, or modify repository content but only reads it, we can explicitly set the `permissions` key for this job to `contents: read`. This ensures the GITHUB_TOKEN is limited in scope, adhering to the least privilege principle. The change should be made by adding the following under the `integration-check:` job definition in `.github/workflows/test-script.yaml`:

```yaml
    permissions:
      contents: read
```

No new imports, methods, or definitions are needed, just the addition of the permissions block in the relevant region of the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
