### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,4 +1,6 @@
 name: Update Repository Badges
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:  # Manually triggered


### PR DESCRIPTION
Potential fix for [https://github.com/Admonstrator/glinet-tailscale-updater/security/code-scanning/8](https://github.com/Admonstrator/glinet-tailscale-updater/security/code-scanning/8)

To fix this problem, we should explicitly set a `permissions` block for the workflow. This block should specify only the permissions needed for the workflow to function properly. Because the workflow checks out the repository and commits and pushes changes, it requires `contents: write`. If it needed to create PRs or write to issues, we would include those, but based on the provided code neither is used, so only `contents: write` is required. The block should be added at the root level of the workflow (right after the `name` and before `on:`) so that it applies to all jobs unless more specific requirements are identified per job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
