### PR TITLE
Adjusting build process to include Peer-Routing

### DIFF
--- a/.github/workflows/build-tailscale.yaml
+++ b/.github/workflows/build-tailscale.yaml
@@ -128,7 +128,7 @@ jobs:
           echo "Custom build version: ${VERSION_SHORT_CUSTOM}"
           # Prepare feature set for smaller binary
           # 1. CORE & NETWORKING                                             
-          KEEP="dns,osrouter,iptables,netstack,health,logtail,portmapper,usermetrics,useroutes"
+          KEEP="dns,osrouter,iptables,netstack,health,logtail,portmapper,usermetrics,useroutes,cli"
           # 2. ROUTING & NODES
           KEEP="${KEEP},advertiseexitnode,useexitnode,advertiseroutes"                           
           KEEP="${KEEP},clientmetrics,cliconndiag,doctor"

--- a/.github/workflows/build-tailscale.yaml
+++ b/.github/workflows/build-tailscale.yaml
@@ -126,23 +126,22 @@ jobs:
           
           echo "Original Tailscale version: ${VERSION_SHORT}"
           echo "Custom build version: ${VERSION_SHORT_CUSTOM}"
-          
-          # Generate small binary tags by removing unneeded features for routers
-          # Keep essential features like DNS, routes, exit nodes, health, peerapiclient/server, etc.
-          # Remove desktop/enterprise features that aren't needed on routers
-          FEATURES_TO_REMOVE="ace,aws,bird,capture,cloud"
-          FEATURES_TO_REMOVE="${FEATURES_TO_REMOVE},completion,debugeventbus,debugportmapper,desktop_sessions"
-          FEATURES_TO_REMOVE="${FEATURES_TO_REMOVE},drive,identityfederation,kube,linkspeed,linuxdnsfight"
-          FEATURES_TO_REMOVE="${FEATURES_TO_REMOVE},netlog,networkmanager,oauthkey,outboundproxy,posture"
-          FEATURES_TO_REMOVE="${FEATURES_TO_REMOVE},relayserver,resolved,sdnotify,synology"
-          FEATURES_TO_REMOVE="${FEATURES_TO_REMOVE},syspolicy,systray,taildrop,tap,tpm,wakeonlan,webclient"
-          SMALL_TAGS=$(go run ./cmd/featuretags --remove="${FEATURES_TO_REMOVE}")
-          # Add ts_include_cli for combined binary support and unixsocketidentity for LocalAPI access control
-          BUILD_TAGS="${SMALL_TAGS},ts_include_cli,osrouter,unixsocketidentity"
-          
+          # Prepare feature set for smaller binary
+          # 1. CORE & NETWORKING                                             
+          KEEP="dns,osrouter,iptables,netstack,health,logtail,portmapper,usermetrics,useroutes"
+          # 2. ROUTING & NODES
+          KEEP="${KEEP},advertiseexitnode,useexitnode,advertiseroutes"                           
+          KEEP="${KEEP},clientmetrics,cliconndiag,doctor"
+          # 4. SECURITY & AUTH
+          KEEP="${KEEP},acme,bakedroots,tailnetlock,unixsocketidentity"
+          # 5. EXTRA                                         
+          KEEP="${KEEP},appconnectors,cachenetmap,colorable,conn25,debug,gro"        
+          KEEP="${KEEP},hujsonconf,lazywg,listenrawdisco,portlist,serve,ssh,useproxy,relayserver"
+          # Finalize build tags
+          BUILD_TAGS=$(go run ./cmd/featuretags --min --add="${KEEP}")
           # Set ldflags with custom version info and stripping
           LDFLAGS="-w -s -X tailscale.com/version.longStamp=${VERSION_LONG_CUSTOM} -X tailscale.com/version.shortStamp=${VERSION_SHORT_CUSTOM}"
-          
+
           # Build the binary
           if [[ "${{ matrix.platform }}" == "mipsle" ]]; then
             CGO_ENABLED=0 GOOS=${{ matrix.os }} GOARCH=${{ matrix.platform }} GOMIPS=softfloat \

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ If you agree to enable Tailscale SSH during installation (manually or by using `
 
 By default, the script uses optimized tiny binaries that:
 - 🔹 Significantly reduce storage footprint
-- 🔹 Maintain full functionality
+- 🔹 Maintain useful functionality for routers
 - 🔹 Skip UPX compression (already optimized)
 - 🔹 Are recommended for all GL.iNet routers
 

--- a/readme.template.md
+++ b/readme.template.md
@@ -190,7 +190,7 @@ If you agree to enable Tailscale SSH during installation (manually or by using `
 
 By default, the script uses optimized tiny binaries that:
 - 🔹 Significantly reduce storage footprint
-- 🔹 Maintain full functionality
+- 🔹 Maintain useful functionality for routers
 - 🔹 Skip UPX compression (already optimized)
 - 🔹 Are recommended for all GL.iNet routers
 


### PR DESCRIPTION
This PR fixes #78 

---
This pull request refines the build process for Tailscale binaries intended for routers, focusing on optimizing feature selection and clarifying documentation. The most important changes include a revised approach to feature tags in the build workflow and updates to documentation to accurately describe the functionality provided by the optimized binaries.

Build process optimization:

* [`.github/workflows/build-tailscale.yaml`](diffhunk://#diff-ee0b92f0d90966dbc51506a335d6fc7157ccd828a836046a072c4e7e5e281d3fL129-R141): Replaced the previous method of removing unnecessary features with an explicit list of features to keep, using the `--min --add` options in `featuretags`. This ensures only essential features for routers are included, improving clarity and maintainability of the build configuration.